### PR TITLE
売上金額＆ポイント表示実装。　商品情報編集画面の画像の不具合修正。（miwa）

### DIFF
--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -6,3 +6,4 @@
 @import "users_sign-up";
 @import "users_sign-in";
 @import "users_account_update";
+@import "users_amount";

--- a/app/assets/stylesheets/_users_amount.scss
+++ b/app/assets/stylesheets/_users_amount.scss
@@ -1,0 +1,55 @@
+.amount_container{
+  height: 100vh;
+  width: 100%;
+  background-color: whitesmoke;
+  padding: 100px 0;
+}
+
+.amount_top_index {
+  width: 700px;
+  margin: 0 auto;
+  font-size: 20px;
+  padding: 8px 0;
+  background-color: white;
+  text-align: center;
+  
+  h2 {
+    font-weight: bold;
+  }
+}
+
+.amount_price_content {
+  width: 700px;
+  height: 250px;
+  margin: 20px auto;
+  display: flex;
+  justify-content: space-evenly;
+  padding: 8px 0;
+  background-color: white;
+  text-align: center;
+  
+  p {
+    margin-top: 100px;
+    font-size: 50px;
+    font-weight: bold;
+  }
+  i {
+    margin-top: 100px;
+    font-size: 50px;
+    font-weight: bold;
+    color: #3CCACE;
+  }
+}
+
+.back_to_mypage {
+  margin: 30px auto;
+  width: 700px;
+  text-align: center;
+  font-size: 18px;
+  
+  a {
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,5 +14,16 @@ class UsersController < ApplicationController
     # 購入した商品
     @buyer_items = @user.buyed_items
   end  
+
+  def amount
+    @user = current_user
+    @sold_items = @user.sold_items
+  end
+
+
+  def point
+    @user = current_user
+    @sold_items = @user.sold_items
+  end
   
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,6 @@ class Item < ApplicationRecord
   belongs_to :user, optional: true 
   has_many :comments
   belongs_to :category
-  has_many :images
   belongs_to :status
   belongs_to :postage_type
   belongs_to :prefecture

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -37,7 +37,7 @@
                 = image.check_box :_destroy, data:{ index: image.index }, class: 'hidden-destroy'
             - if @item.persisted?
               .js-file_group{"data-index" => "#{@item.images.count}"}
-                = file_field_tag :image_url, name: "product[images_attributes][#{@item.images.count}][src]", class: 'js-file'
+                = file_field_tag :image_url, name: "item[images_attributes][#{@item.images.count}][image_url]", class: 'js-file'
                 .js-remove 削除
 
         .field__error-text

--- a/app/views/users/amount.html.haml
+++ b/app/views/users/amount.html.haml
@@ -1,0 +1,14 @@
+.amount_container
+  .amount_top_index
+    %h2 #{@user.nickname}さんの売上金額
+
+  .amount_price_content
+    - amount_price = 0
+    - @sold_items.each do |item|
+      - amount_price = amount_price + item.price
+    = icon("fas", "coins")
+    %p #{amount_price}円
+
+  .back_to_mypage
+    = link_to "マイページへ戻る", user_path(@user)
+ 

--- a/app/views/users/point.html.haml
+++ b/app/views/users/point.html.haml
@@ -1,0 +1,16 @@
+.amount_container
+  .amount_top_index
+    %h2 #{@user.nickname}さんのポイント
+
+  .amount_price_content
+    - amount_price = 0
+    - point = 0
+    - @sold_items.each do |item|
+      - amount_price = amount_price + item.price
+      - point = (amount_price * 0.1).round(0)
+    = icon("fab", "pinterest-square")
+    %p #{point}pt
+
+  .back_to_mypage
+    = link_to "マイページへ戻る", user_path(@user)
+ 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -53,9 +53,9 @@
     %p 売上情報
     %ul
       %list 
-        %a(href="#") 売上金額
+        = link_to '売上金額', amount_user_path(@user)
       %list 
-        %a(href="#") ポイント
+        = link_to 'ポイント', point_user_path(@user)
   .user_content__config
     %p 設定
     %ul

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,12 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :users, only: [:show]
+  resources :users, only: [:show] do
+    member do
+      get 'amount'
+      get 'point'
+    end
+  end
   resources :sending_destinations, only: [:new, :create, :edit, :update]
   resources :cards, only: [:new, :create]
   


### PR DESCRIPTION
# what
・ユーザーマイページから売上金額とポイント（売上金額の10%）が確認できる様に実装。
（実際の商品売上金額と連動してます）
・前回のスプリントレビューで指摘された、商品情報編集ページでの画像の追加・削除の動作修正。


# why
・売上金額やポイントを可視化する事で、より商品売買を意識したアプリにする。
・商品情報編集時の画像の追加・修正で不具合があったので、その部分の修正。

# 売上金額画面
![スクリーンショット 2020-08-17 20 35 07](https://user-images.githubusercontent.com/63687239/90392127-417d4b00-e0c9-11ea-83f5-d05e9cf604bb.png)

# ポイント画面
![スクリーンショット 2020-08-17 20 36 38](https://user-images.githubusercontent.com/63687239/90392193-61147380-e0c9-11ea-9dc5-ee6812802bcf.png)
